### PR TITLE
For .NET Core, TcpClient doesn't support the .Connect() API

### DIFF
--- a/EasyModbusTCPCore/ModbusClient.cs
+++ b/EasyModbusTCPCore/ModbusClient.cs
@@ -10,6 +10,7 @@ using System.Net;
 using System.Reflection;
 using System.Text;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace EasyModbus
 {
@@ -73,13 +74,13 @@ namespace EasyModbus
 		/// <summary>
 		/// Establish connection to Master device in case of Modbus TCP. Opens COM-Port in case of Modbus RTU
 		/// </summary>
-		public void Connect()
+		public async Task Connect()
 		{
 
             if (debug) StoreLogData.Instance.Store("Open TCP-Socket, IP-Address: " + ipAddress + ", Port: " + port, System.DateTime.Now);
             tcpClient = new TcpClient();
 
-            var result = tcpClient.ConnectAsync(ipAddress, port);
+            await tcpClient.ConnectAsync(ipAddress, port);
 
 
             //tcpClient = new TcpClient(ipAddress, port);
@@ -91,13 +92,13 @@ namespace EasyModbus
 		/// <summary>
 		/// Establish connection to Master device in case of Modbus TCP.
 		/// </summary>
-		public void Connect(string ipAddress, int port)
+		public async Task Connect(string ipAddress, int port)
 		{
  
                 if (debug) StoreLogData.Instance.Store("Open TCP-Socket, IP-Address: " + ipAddress + ", Port: " + port, System.DateTime.Now);
                 tcpClient = new TcpClient();
 
-                 var result = tcpClient.ConnectAsync(ipAddress, port);
+                 await tcpClient.ConnectAsync(ipAddress, port);
            
 
                 //tcpClient = new TcpClient(ipAddress, port);


### PR DESCRIPTION
TcpClient only supports ConnectAsync() in .NET Core. This requires that our .Connect() wrapper wait for the .ConnectAsync() call to complete before calling .GetStream(), so we will make the .Connect() method awaitable.