### PR TITLE
Don't reset countRetries to prevent endless loop

### DIFF
--- a/EasyModbus/ModbusClient.cs
+++ b/EasyModbus/ModbusClient.cs
@@ -1730,7 +1730,6 @@ namespace EasyModbus
                 	data = new byte[2100];
                 	Array.Copy(readBuffer, 0, data, 6, readBuffer.Length);
                 	receivedUnitIdentifier = data[6];
-                    countRetries = 0;
                 }
               
             }


### PR DESCRIPTION
WriteSingleCoil loops indefinitely because countRetries is reset on every recursive call. Similar to #30, but for writing to coils.